### PR TITLE
erroneous placeholder for json output, which does nothing, will require reconsidering interface approach. Knew this would happen, but alas, here we are.

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func (cmd *UsageReportCmd) GetMetadata() plugin.PluginMetadata {
 					Usage: "cf usage-report [-o orgName...] --format formatChoice",
 					Options: map[string]string{
 						"o":         "organization(s) included in report. Flag can be provided multiple times.",
-						"format":    "format to print as (options: string,table) (default: table)",
+						"format":    "format to print as (options: string,table,json) (default: table)",
 						"log-level": "(options: info,debug,trace) (default: info)",
 					},
 				},

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func (cmd *UsageReportCmd) GetMetadata() plugin.PluginMetadata {
 		Version: plugin.VersionType{
 			Major: 2,
 			Minor: 9,
-			Build: 1,
+			Build: 2,
 		},
 		Commands: []plugin.Command{
 			{

--- a/presenters/json_presenter.go
+++ b/presenters/json_presenter.go
@@ -1,5 +1,9 @@
 package presenters
 
-func (p *Presenter) asJSON() {
+import (
+	log "github.com/sirupsen/logrus"
+)
 
+func (p *Presenter) asJSON() {
+	log.Fatalln("uhhh... TODO. You probably shouldn't have used interfaces for the reporters, you should 've used structs. But it made sense at the time.")
 }

--- a/presenters/json_presenter.go
+++ b/presenters/json_presenter.go
@@ -1,0 +1,5 @@
+package presenters
+
+func (p *Presenter) asJSON() {
+
+}

--- a/presenters/presenter.go
+++ b/presenters/presenter.go
@@ -25,6 +25,8 @@ func (p *Presenter) Render() {
 		p.asString()
 	case "table":
 		p.asTable()
+	case "json":
+		p.asJSON()
 	default:
 		// TODO
 		// yeah this is kind of awful I know, I'm sorry, I'm still learning,


### PR DESCRIPTION
attempt at json presenter?

this would be pretty dang important since it allows for significantly easier parsing with tools like `jq` and would allow for "quota recommendations" to be consumed via json and used in other systems like cf-mgmt, etc.

https://github.com/aegershman/cf-usage-report-plugin/issues/20


I have a feeling decisions made recently about using interfaces for the reporter are going to bite me